### PR TITLE
Hide search bar on Add Triplers page

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -58,9 +58,9 @@ const renderTable = (batchActionClick) => (
             Add
         </TableBatchAction>
         </TableBatchActions>
-        <TableToolbarContent>
+        {/* <TableToolbarContent>
           <TableToolbarSearch onChange={onInputChange} />
-        </TableToolbarContent>
+        </TableToolbarContent> */}
       </TableToolbar>
       <Table {...getTableProps()} size='tall'>
         <TableHead>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13405391/86620560-2247b580-bf82-11ea-842a-8bf2e1357ddf.png)

wondering tho, if for now the experience of searching the triplers via this bar would be useful until we could implement better granular search?

![data-table-search](https://user-images.githubusercontent.com/13405391/86620679-5c18bc00-bf82-11ea-9883-4af3fbb59fb8.gif)
