### PR TITLE
Ui fixes

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/src/components/AddressForm.js
+++ b/src/components/AddressForm.js
@@ -32,7 +32,6 @@ export default ({ ambassador }) => (
         name="address1"
         invalidText="Invalid error message."
         labelText="Street Address*"
-        placeholder="1234 Ambassador Lane"
         defaultValue={ambassador.address.address1}
         required
       />
@@ -42,7 +41,6 @@ export default ({ ambassador }) => (
         name="city"
         invalidText="Invalid error message."
         labelText="City*"
-        placeholder="San Francisco"
         defaultValue={ambassador.address.city}
         required
       />
@@ -57,7 +55,6 @@ export default ({ ambassador }) => (
             itemToString={(item) => (item ? item.text : '')}
             items={states}
             onChange={(value) => console.log(value)}
-            placeholder=" "
             titleText="State*"
             type="default"
             selectedItem={states.find(item => {
@@ -71,7 +68,6 @@ export default ({ ambassador }) => (
             name="zip"
             invalidText="Invalid error message."
             labelText="Zip Code*"
-            placeholder="12345"
             defaultValue={ambassador.address.zip}
             required
           />

--- a/src/components/AddressForm.js
+++ b/src/components/AddressForm.js
@@ -67,7 +67,7 @@ export default ({ ambassador }) => (
           <TextInput
             name="zip"
             invalidText="Invalid error message."
-            labelText="Zip Code*"
+            labelText="ZIP Code*"
             defaultValue={ambassador.address.zip}
             required
           />

--- a/src/components/Onboarding/01.js
+++ b/src/components/Onboarding/01.js
@@ -12,10 +12,10 @@ export default () => {
       title="Training"
       submitButtonTitle="Continue"
     >
-      <p>Voting Ambassadors understand the importance of voting in bringing positive change to their communities. By recruiting "Vote Triplers" — friends and family members who agree to remind three other people to vote in the next election — Voting Ambassadors give their communities a more <strong>powerful</strong> voice.</p>
+      <p>Voting Ambassadors understand the importance of <strong>voting</strong> in bringing positive change to their communities. By recruiting "Vote Triplers" — friends and family members who agree to remind three other people to vote in the next election — Voting Ambassadors give their communities a more powerful voice.</p>
       <br />
       <br />
-      <p>To become a Voting Ambassador, you must complete the following 20-minute training and schedule a 5-minute phone interview with an Organizer from BlockPower.</p>
+      <p>To become a Voting Ambassador, you must complete the following 15-minute training and schedule a 10-minute phone interview with an Organizer from BlockPower.</p>
     </PageLayout>
   )
 }

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -1,38 +1,36 @@
 import React from 'react'
-import { Grid, Column, Row, Form } from 'carbon-components-react'
+import { Grid, Column, Row, Form, Content } from 'carbon-components-react'
 import styled from 'styled-components'
 import { spacing, colors } from '../theme'
 import Menu from './Menu'
 import Button from './Button'
 import { InlineNotification } from 'carbon-components-react'
 
-const ContentContainer = styled(Grid)`
+const ContentContainer = styled(Content)`
   padding: ${ spacing[3] };
-  padding-top: ${ spacing[8] };
   padding-bottom: ${ spacing[10] };
-  height: 100vh;
-  margin-top: 0;
-  overflow-y: scroll;
 `
 
 const TitleContainer = styled(Row)`
-  margin-top: ${ spacing[7] };
+  margin-top: ${ spacing[5] };
   margin-bottom: ${ spacing[7] };
 `
 
 const CtaButtonContainer = styled(Column)`
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
-  background-color: ${ colors.white };
   z-index: 1;
 `
 
-const CtaButton = styled(Button)`
+const InlineNotificationStyled = styled(InlineNotification)`
   width: 100%;
   max-width: 100%;
-  margin-top: 0;
   margin-bottom: ${ spacing[3] };
+`
+
+const CtaButton = styled(Button)`
+  margin-top: 0;
 `
 
 export default ({ header, title, children, submitButtonTitle, onClickSubmit, formId, error }) => (
@@ -51,22 +49,25 @@ export default ({ header, title, children, submitButtonTitle, onClickSubmit, for
             { children }
           </Row>
         </Column>
-        <CtaButtonContainer lg={{ span: 4, offset: 3 }} md={{ span: 4, offset: 1 }} sm={{ span: 4 }}>
-          <Row>
-            {error &&
-              <InlineNotification
-                kind="error"
-                icondescription="Dismiss notification"
-                subtitle={error}
-                title="Oops!"
-              />
-            }
-            {submitButtonTitle && (
-              <CtaButton type="submit" id={formId}>{submitButtonTitle}</CtaButton>
-            )}
-          </Row>
-        </CtaButtonContainer>
       </Form>
     </ContentContainer>
+    <CtaButtonContainer lg={{ span: 4, offset: 3 }} md={{ span: 4, offset: 1 }} sm={{ span: 4 }}>
+      <Row>
+        {error && (
+          <InlineNotification
+            hideCloseButton
+            kind="error"
+            icondescription="Dismiss notification"
+            subtitle={error}
+            title="Oops!"
+          />
+        )}
+        {submitButtonTitle && (
+          <CtaButton type="submit" id={formId}>
+            {submitButtonTitle}
+          </CtaButton>
+        )}
+      </Row>
+    </CtaButtonContainer>
   </>
 )

--- a/src/components/PendingApprovalPage.js
+++ b/src/components/PendingApprovalPage.js
@@ -17,8 +17,9 @@ export default () => {
         title='Training Complete!'
       >
         <p>
-          A program administrator will review your application and be in touch with you soon.
-          In the meantime, please choose a convenient date and time below: 
+          Thank you for completing the training. The final step in the
+          application process is a ten-minute phone interview. Please choose a
+          convenient date and time.
         </p>
         <br />
         <br />

--- a/src/components/Profile/ContactInfo.js
+++ b/src/components/Profile/ContactInfo.js
@@ -32,7 +32,6 @@ export default () => (
           id="first_name"
           invalidText="Invalid error message."
           labelText="First Name"
-          placeholder="Joan"
         />
       </FormGroup>
       <FormGroup>
@@ -40,7 +39,6 @@ export default () => (
           id="last_name"
           invalidText="Invalid error message."
           labelText="Last Name"
-          placeholder="Ambassador"
         />
       </FormGroup>
       <FormGroup>
@@ -48,7 +46,6 @@ export default () => (
           id="email"
           invalidText="Invalid error message."
           labelText="Email"
-          placeholder="joanambassador@email.co"
         />
       </FormGroup>
       <FormGroup>
@@ -56,7 +53,6 @@ export default () => (
           id="phone"
           invalidText="Invalid error message."
           labelText="Phone number"
-          placeholder="(123) 456-7890"
         />
       </FormGroup>
       <SectionTitle>Address</SectionTitle>

--- a/src/components/SignUp/ContactInfoPage.js
+++ b/src/components/SignUp/ContactInfoPage.js
@@ -4,15 +4,7 @@ import { spacing } from '../../theme'
 import PageLayout from '../PageLayout'
 import Breadcrumbs from '../Breadcrumbs'
 import AddressForm from '../AddressForm'
-import {
-  Form,
-  FormGroup,
-  TextInput,
-  Select,
-  SelectItem,
-  DatePicker,
-  DatePickerInput
-} from 'carbon-components-react'
+import { FormGroup, TextInput } from 'carbon-components-react'
 import { useHistory } from 'react-router-dom'
 import { AppContext } from '../../api/AppContext'
 
@@ -80,7 +72,6 @@ export const ContactInfoPage = () => {
           name="first_name"
           invalidText="Invalid error message."
           labelText="First Name*"
-          placeholder="Joan"
           defaultValue={ambassador.first_name}
           required
         />
@@ -90,21 +81,9 @@ export const ContactInfoPage = () => {
           name="last_name"
           invalidText="Invalid error message."
           labelText="Last Name*"
-          placeholder="Ambassador"
           defaultValue={ambassador.last_name}
           required
         />
-      </FormGroup>
-      <FormGroup style={{width: "50%"}}>
-        <DatePicker dateFormat="m/d/Y" datePickerType="single">
-          <DatePickerInput
-            name="date_of_birth"
-            placeholder="mm/dd/yyyy"
-            labelText="Date of Birth"
-            type="text"
-            defaultValue={ambassador.date_of_birth}
-          />
-        </DatePicker>
       </FormGroup>
       <SectionTitle>Address</SectionTitle>
       <AddressForm ambassador={ambassador}/>
@@ -114,7 +93,6 @@ export const ContactInfoPage = () => {
           name="email"
           invalidText="Invalid error message."
           labelText="Email"
-          placeholder="joanambassador@email.co"
           defaultValue={ambassador.email}
         />
       </FormGroup>
@@ -123,7 +101,6 @@ export const ContactInfoPage = () => {
           name="phone"
           invalidText="Invalid error message."
           labelText="Phone number*"
-          placeholder="(123) 456-7890"
           defaultValue={ambassador.phone}
           required
         />

--- a/src/components/SignUp/ContactPage.js
+++ b/src/components/SignUp/ContactPage.js
@@ -42,7 +42,6 @@ export const ContactPage = () => {
           name="email"
           invalidText="Invalid error message."
           labelText="Email"
-          placeholder="joanambassador@email.co"
         />
       </FormGroup>
       <FormGroup>
@@ -50,7 +49,6 @@ export const ContactPage = () => {
           name="phone"
           invalidText="Invalid error message."
           labelText="Phone number*"
-          placeholder="(123) 456-7890"
           required
         />
       </FormGroup>

--- a/src/components/SignUp/PersonalInfoPage.js
+++ b/src/components/SignUp/PersonalInfoPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PageLayout from '../PageLayout'
 import Breadcrumbs from '../Breadcrumbs'
-import { FormGroup, TextInput, DatePicker, DatePickerInput } from 'carbon-components-react'
+import { FormGroup, TextInput } from 'carbon-components-react'
 import { useHistory } from 'react-router-dom'
 import { AppContext } from '../../api/AppContext'
 
@@ -37,7 +37,6 @@ export const PersonalInfoPage = () => {
           name="first_name"
           invalidText="Invalid error message."
           labelText="First Name*"
-          placeholder="Joan"
           required
         />
       </FormGroup>
@@ -46,18 +45,9 @@ export const PersonalInfoPage = () => {
           name="last_name"
           invalidText="Invalid error message."
           labelText="Last Name*"
-          placeholder="Ambassador"
           required
         />
       </FormGroup>
-      <DatePicker dateFormat="m/d/Y" datePickerType="single">
-        <DatePickerInput
-          name="dob"
-          placeholder="mm/dd/yyyy"
-          labelText="Date of Birth"
-          type="text"
-        />
-      </DatePicker>
     </PageLayout>
   )
 }

--- a/src/components/Triplers/AddTripler.js
+++ b/src/components/Triplers/AddTripler.js
@@ -49,7 +49,7 @@ const AddTriplersPage = ({ triplers, claimTriplers }) => {
             route: "/"
           },
           {
-            name: "Triplers",
+            name: "Vote Triplers",
             route: "/"
           },
           {

--- a/src/components/Triplers/ConfirmPage.js
+++ b/src/components/Triplers/ConfirmPage.js
@@ -78,7 +78,6 @@ const ConfirmPage = ({ tripler, confirmTriplers, loading }) => {
           name="triplee1"
           invalidText="Invalid error message."
           labelText="Name 1*"
-          placeholder="Name"
           required
         />
       </FormGroup>
@@ -87,7 +86,6 @@ const ConfirmPage = ({ tripler, confirmTriplers, loading }) => {
           name="triplee2"
           invalidText="Invalid error message."
           labelText="Name 2*"
-          placeholder="Name"
           required
         />
       </FormGroup>
@@ -96,7 +94,6 @@ const ConfirmPage = ({ tripler, confirmTriplers, loading }) => {
           name="triplee3"
           invalidText="Invalid error message."
           labelText="Name 3*"
-          placeholder="Name"
           required
         />
       </FormGroup>
@@ -106,7 +103,6 @@ const ConfirmPage = ({ tripler, confirmTriplers, loading }) => {
           name="phone"
           invalidText="Invalid error message."
           labelText={`${tripler.first_name}'s Phone Number*`}
-          placeholder="123-456-7890"
           required
         />
       </FormGroup>

--- a/src/components/Triplers/ConfirmPage.js
+++ b/src/components/Triplers/ConfirmPage.js
@@ -61,7 +61,7 @@ const ConfirmPage = ({ tripler, confirmTriplers, loading }) => {
               route: "/",
             },
             {
-              name: "Triplers",
+              name: "Vote Triplers",
               route: "/",
             },
             {

--- a/src/components/Triplers/TriplersPage.js
+++ b/src/components/Triplers/TriplersPage.js
@@ -88,8 +88,7 @@ const Triplers = ({ unconfirmed, pending, confirmed, remindTripler }) => {
       </p>
       <br />
       <p>
-        You will receive $50 for each Vote Tripler you recruit and a $Y bonus
-        for each Vote Tripler who goes on to become a Voting Ambassador.
+        You will receive $50 for each Vote Tripler you recruit.
       </p>
       <Button
         href="/triplers/add"

--- a/src/components/Triplers/TriplersPage.js
+++ b/src/components/Triplers/TriplersPage.js
@@ -95,7 +95,7 @@ const Triplers = ({ unconfirmed, pending, confirmed, remindTripler }) => {
         href="/triplers/add"
         disabled={hasMaxTriplers}
       >
-        Find new Triplers
+        Find new Vote Triplers
         <Add16 />
       </Button>
       
@@ -182,7 +182,7 @@ const TriplersPage = ({ triplers, remindTripler }) => {
             route: "/"
           },
           {
-            name: "Triplers",
+            name: "Vote Triplers",
             route: "/"
           }
         ]

--- a/src/components/Triplers/TriplersPage.js
+++ b/src/components/Triplers/TriplersPage.js
@@ -63,7 +63,8 @@ const TriplerRow = ({ name, address, id, unconfirmed, pending, remindTripler, co
           Remind
         </Button>
       }
-      {confirmed &&
+      {/* FIXME: Hardcode fake confirmation */}
+      {confirmed && tagText &&
         <Tag type="green">
           {tagText}
         </Tag>

--- a/src/components/Triplers/TriplersPage.js
+++ b/src/components/Triplers/TriplersPage.js
@@ -177,14 +177,12 @@ const TriplersPage = ({ triplers, remindTripler }) => {
       }/>}
     >
       {
-        !triplers ?
-          <TriplersEmpty/> :
-          <Triplers
-            unconfirmed={unconfirmed}
-            pending={pending}
-            confirmed={confirmed}
-            remindTripler={remindTripler}
-          />
+        <Triplers
+          unconfirmed={unconfirmed}
+          pending={pending}
+          confirmed={confirmed}
+          remindTripler={remindTripler}
+        />
       }
     </PageLayout>
   )

--- a/src/components/Triplers/TriplersPage.js
+++ b/src/components/Triplers/TriplersPage.js
@@ -73,71 +73,82 @@ const TriplerRow = ({ name, address, id, unconfirmed, pending, remindTripler, co
   </TriplerRowStyled>
 )
 
-const TriplersEmpty = () => (
-  <>
-    <p>
-      Confirm that these people will ask 3 friends to vote and earn 50 dollars
-    </p>
-    <Button href='/triplers/add'>Find new Triplers<Add16 /></Button>
-  </>
-)
-const Triplers = ({ unconfirmed, pending, confirmed, remindTripler }) => (
-  <>
-    <p>
-      As a Voting Ambassador, your task is to recruit “Vote Triplers” from a list of family members and neighbors. A Vote Tripler is someone who agrees to remind three other people to vote in the next election.
-    </p>
-    <p>
-      You will receive $50 for each Vote Tripler you recruit.
-    </p>
-    <Button href='/triplers/add' disabled={unconfirmed.length + confirmed.length + pending.length >= 12}>Find new Triplers<Add16 /></Button>
-    <SectionTitle>Your possible Vote Triplers</SectionTitle>
-    <Paragraph>Add information for a Tripler. We’ll send them a text message to confirm.</Paragraph>
-    {
-      unconfirmed &&
-        unconfirmed.map((tripler) => (
-          <TriplerRow
-            id={tripler.id}
-            name={`${tripler.first_name} ${tripler.last_name}`}
-            address={`${tripler.address.address1} ${tripler.address.city} ${tripler.address.state}`}
-            unconfirmed
-            onClick={() => { }}
-          />
-        ))
-    }
-    <SectionTitle>Your unconfirmed Vote Triplers</SectionTitle>
-    <Paragraph>These possible Vote Triplers have not yet confirmed their identity.</Paragraph>
-    {
-      pending &&
-        pending.map((tripler) => (
-          <TriplerRow
-            id={tripler.id}
-            name={`${tripler.first_name} ${tripler.last_name}`}
-            address={`${tripler.address.address1} ${tripler.address.city} ${tripler.address.state}`}
-            onClick={() => { }}
-            pending
-            remindTripler={remindTripler}
-          />
-        ))
-    }
-    <SectionTitle>Your confirmed Vote Triplers</SectionTitle>
-    <Paragraph>
-      Once your <Link href="#">payment method is set up</Link>, you’ll receive payment for these Vote Triplers
-    </Paragraph>
-    {
-      confirmed &&
-        confirmed.map((tripler, i) => (
-          <TriplerRow
-            name={`${tripler.first_name} ${tripler.last_name}`}
-            address={`${tripler.address.address1} ${tripler.address.city} ${tripler.address.state}`}
-            onClick={() => { }}
-            confirmed
-            // FIXME: Hardcode fake confirmation
-            tagText={i === 0 ? "$50 In Transit" : "$50 Collected"}
-          />
-        ))
-    }
-  </>
-)
+const Triplers = ({ unconfirmed, pending, confirmed, remindTripler }) => {
+  const hasTriplers =
+    unconfirmed.length > 0 || pending.length > 0 || confirmed.length > 0;
+  const hasMaxTriplers = 
+    unconfirmed.length + confirmed.length + pending.length >= 12
+
+  return (
+    <>
+      <p>
+        As a Voting Ambassador, your task is to recruit “Vote Triplers” from a
+        list of family members and neighbors. A Vote Tripler is someone who
+        agrees to remind three other people to vote in the next election.
+      </p>
+      <br />
+      <p>
+        You will receive $50 for each Vote Tripler you recruit and a $Y bonus
+        for each Vote Tripler who goes on to become a Voting Ambassador.
+      </p>
+      <Button
+        href="/triplers/add"
+        disabled={hasMaxTriplers}
+      >
+        Find new Triplers
+        <Add16 />
+      </Button>
+      
+      {hasTriplers && (
+        <>
+          <SectionTitle>Your possible Vote Triplers</SectionTitle>
+          <Paragraph>
+            Add information for a Tripler. We’ll send them a text message to
+            confirm.
+          </Paragraph>
+          {unconfirmed.map((tripler) => (
+            <TriplerRow
+              id={tripler.id}
+              name={`${tripler.first_name} ${tripler.last_name}`}
+              address={`${tripler.address.address1} ${tripler.address.city} ${tripler.address.state}`}
+              unconfirmed
+              onClick={() => {}}
+            />
+          ))}
+
+          <SectionTitle>Your unconfirmed Vote Triplers</SectionTitle>
+          <Paragraph>
+            These possible Vote Triplers have not yet confirmed their identity.
+          </Paragraph>
+          {pending.map((tripler) => (
+            <TriplerRow
+              id={tripler.id}
+              name={`${tripler.first_name} ${tripler.last_name}`}
+              address={`${tripler.address.address1} ${tripler.address.city} ${tripler.address.state}`}
+              onClick={() => {}}
+              pending
+              remindTripler={remindTripler}
+            />
+          ))}
+
+          <SectionTitle>Your confirmed Vote Triplers</SectionTitle>
+          <Paragraph>
+            Once your <Link href="#">payment method is set up</Link>, you’ll
+            receive payment for these Vote Triplers
+          </Paragraph>
+          {confirmed.map((tripler, i) => (
+            <TriplerRow
+              name={`${tripler.first_name} ${tripler.last_name}`}
+              address={`${tripler.address.address1} ${tripler.address.city} ${tripler.address.state}`}
+              onClick={() => {}}
+              confirmed
+            />
+          ))}
+        </>
+      )}
+    </>
+  );
+};
 
 export default () => {
   const [triplers, setTriplers] = useState(null)
@@ -177,14 +188,12 @@ const TriplersPage = ({ triplers, remindTripler }) => {
         ]
       }/>}
     >
-      {
-        <Triplers
-          unconfirmed={unconfirmed}
-          pending={pending}
-          confirmed={confirmed}
-          remindTripler={remindTripler}
-        />
-      }
+      <Triplers
+        unconfirmed={unconfirmed}
+        pending={pending}
+        confirmed={confirmed}
+        remindTripler={remindTripler}
+      />
     </PageLayout>
   )
 }

--- a/src/stories/Triplers.stories.js
+++ b/src/stories/Triplers.stories.js
@@ -7,9 +7,60 @@ export default {
   title: 'Triplers'
 }
 
-// export const TriplersEmptyPage = () => (
-//   <Triplers empty />
-// )
+export const TriplersEmptyPage = () => (
+  <Triplers triplers={[]} />
+)
+
+export const UnconfirmedTriplers = () => (
+  <Triplers
+    triplers={[
+      {
+        status: "unconfirmed",
+        first_name: "Lauren",
+        last_name: "R",
+        address: {
+          address1: "200 Address lane",
+          city: "Denver",
+          state: "CO",
+        },
+      },
+    ]}
+  />
+);
+
+export const PendingTriplers = () => (
+  <Triplers
+    triplers={[
+      {
+        status: "pending",
+        first_name: "Lauren",
+        last_name: "R",
+        address: {
+          address1: "200 Address lane",
+          city: "Denver",
+          state: "CO",
+        },
+      },
+    ]}
+  />
+);
+
+export const ConfirmedTriplers = () => (
+  <Triplers
+    triplers={[
+      {
+        status: "confirmed",
+        first_name: "Lauren",
+        last_name: "R",
+        address: {
+          address1: "200 Address lane",
+          city: "Denver",
+          state: "CO",
+        },
+      },
+    ]}
+  />
+);
 
 export const TriplersPage = () => (
   <Triplers


### PR DESCRIPTION
HVAMB-76  — Signup screens continue/submit buttons on mobile need readjustment
HVAMB-114  — Sign up-Dropdown section of state tricky on mobile
HVAMB-50  — UI-Add triplers list scrolls up to show unwanted long white scroll area

HVAMB-117  — Remove field placeholder text on signup forms
HVAMB-119 — Remove DOB field from first signup form page
HVAMB-120 — Text changes
HVAMB-121  — When no Triplers have been selected yet, hide all text below “Find New Triplers” on My Vote Triplers
HVAMB-122 — Hide green payment “pill” from Confirmed Triplers on My Vote Triplers page