### PR TITLE
Allow kubernetes to pull the image even though it's private

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: |
-        cd .deploy
-        helmfile --log-level debug apply
+         cd .deploy
+         helmfile --log-level debug apply
 
 workflows:
    deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ workflows:
      jobs:
        - deploy-to-coopernetes:
            context: coopernetes-staging
-           #           filters:
-           #             branches:
-           #               only: develop
+           filters:
+             branches:
+               only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: |
-          /deploy.sh
-          cd .deploy
-          helmfile --log-level debug apply
+      - run: /deploy.sh
 
 workflows:
    deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,6 @@ workflows:
      jobs:
        - deploy-to-coopernetes:
            context: coopernetes-staging
-           filters:
-             branches:
-               only: develop
+           #           filters:
+           #             branches:
+           #               only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,9 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: |
-         cd .deploy
-         helmfile --log-level debug apply
+          /deploy.sh
+          cd .deploy
+          helmfile --log-level debug apply
 
 workflows:
    deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: /deploy.sh
+      - run: |
+        cd .deploy
+        helmfile --log-level debug apply
 
 workflows:
    deploy:

--- a/.deploy/chart/templates/_dockerconfigjson.tpl
+++ b/.deploy/chart/templates/_dockerconfigjson.tpl
@@ -1,5 +1,5 @@
 {{- define "dockerconfigjson" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password) }}
 {{- end }}
 {{- end }}

--- a/.deploy/chart/templates/_dockerconfigjson.tpl
+++ b/.deploy/chart/templates/_dockerconfigjson.tpl
@@ -1,0 +1,5 @@
+{{- define "dockerconfigjson" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}

--- a/.deploy/chart/templates/_dockerconfigjson.tpl
+++ b/.deploy/chart/templates/_dockerconfigjson.tpl
@@ -1,5 +1,5 @@
 {{- define "dockerconfigjson" }}
 {{- with .Values.imageCredentials }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password) }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}

--- a/.deploy/chart/templates/deployment.yaml
+++ b/.deploy/chart/templates/deployment.yaml
@@ -22,3 +22,5 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      imagePullSecrets:
+      - name: {{ .Values.name }}-image-pull-secret

--- a/.deploy/chart/templates/imagePullSecret.yaml
+++ b/.deploy/chart/templates/imagePullSecret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: myregistrykey
+  name: colabcoopdevops-dockerhub
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "dockerconfigjson" . }}

--- a/.deploy/chart/templates/imagePullSecret.yaml
+++ b/.deploy/chart/templates/imagePullSecret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: colabcoopdevops-dockerhub
+  name: {{ .Values.name }}-image-pull-secret
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "dockerconfigjson" . }}

--- a/.deploy/chart/templates/imagePullSecret.yaml
+++ b/.deploy/chart/templates/imagePullSecret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myregistrykey
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "dockerconfigjson" . }}

--- a/.deploy/helmfile.yaml
+++ b/.deploy/helmfile.yaml
@@ -11,6 +11,6 @@ releases:
           port: 80
         imageCredentials:
           registry: index.docker.io/v1/
-          username: { requiredEnv "DOCKER_USER" }
-          password: { requiredEnv "DOCKER_PASSWORD" }
+          username: {{ requiredEnv "DOCKER_USER" }}
+          password: {{ requiredEnv "DOCKER_PASSWORD" }}
           email: devops+dockerhub@colab.coop

--- a/.deploy/helmfile.yaml
+++ b/.deploy/helmfile.yaml
@@ -10,7 +10,7 @@ releases:
           tag: {{ requiredEnv "DOCKER_TAG" }}
           port: 80
         imageCredentials:
-          registry: index.docker.io/v1/
+          registry: https://index.docker.io/v1/
           username: {{ requiredEnv "DOCKER_USER" }}
           password: {{ requiredEnv "DOCKER_PASSWORD" }}
           email: devops+dockerhub@colab.coop

--- a/.deploy/helmfile.yaml
+++ b/.deploy/helmfile.yaml
@@ -9,3 +9,8 @@ releases:
         image:
           tag: {{ requiredEnv "DOCKER_TAG" }}
           port: 80
+        imageCredentials:
+          registry: https://index.docker.io/v1/
+          username: { requiredEnv "DOCKER_USER" }
+          password: { requiredEnv "DOCKER_PASSWORD" }
+          email: devops+dockerhub@colab.coop

--- a/.deploy/helmfile.yaml
+++ b/.deploy/helmfile.yaml
@@ -10,7 +10,7 @@ releases:
           tag: {{ requiredEnv "DOCKER_TAG" }}
           port: 80
         imageCredentials:
-          registry: https://index.docker.io/v1/
+          registry: index.docker.io/v1/
           username: { requiredEnv "DOCKER_USER" }
           password: { requiredEnv "DOCKER_PASSWORD" }
           email: devops+dockerhub@colab.coop


### PR DESCRIPTION
When we first launched, all the images were public for ease of use. These changes allow the cluster to pull private images. 