### PR TITLE
Update payments button in header

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
-import { Help20, UserAvatar20 } from '@carbon/icons-react'
+import { Help20, Wallet20 } from '@carbon/icons-react'
 import styled, { ThemeProvider } from 'styled-components'
 import BlockPower from '../assets/logos/block-power.png'
 import NewGeorgia from '../assets/logos/new-georgia.png'
@@ -112,11 +112,13 @@ export default () => {
             <Help20 />
           </HeaderGlobalAction>
           <HeaderGlobalAction
-            aria-label="Profile"
+            aria-label="Payments"
             type="button"
-            onClick={() => {}}
+            onClick={() => {
+              redirect("/payments");
+            }}
           >
-            <UserAvatar20 />
+            <Wallet20 />
           </HeaderGlobalAction>
         </HeaderGlobalBar>
       </Header>

--- a/src/components/Payments/AddPage.js
+++ b/src/components/Payments/AddPage.js
@@ -52,11 +52,11 @@ export default () => {
             },
             {
               name: "Payments",
-              route: "/",
+              route: "/payments",
             },
             {
               name: "Add",
-              route: "/",
+              route: "/payments/add",
             },
           ]}
         />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13405391/88581367-ab4a8d80-d012-11ea-83ba-038055475275.png)

https://colabcoop.atlassian.net/browse/HVAMB-144 — Payments - Ambassador can click dollar sign icon on header bar to view /payments page

https://colabcoop.atlassian.net/browse/HVAMB-217 — Change person icon in header to dollar sign icon

https://colabcoop.atlassian.net/browse/HVAMB-220 — breadcrumb 'Payments' link on Add payment page wrongly redirecting to vote triplers page

