### PR TITLE
HVAMB-218: Add link on /triplers to set up payment account if not set…

### DIFF
--- a/src/components/Triplers/TriplersPage.js
+++ b/src/components/Triplers/TriplersPage.js
@@ -138,7 +138,8 @@ const Triplers = ({ unconfirmed, pending, confirmed, remindTripler }) => {
 
           <SectionTitle>Your confirmed Vote Triplers</SectionTitle>
           <Paragraph>
-            You'll receive payment for these Vote Triplers.
+            Once your <Link href="#/payments">payment method is set up</Link>,
+            you’ll receive payment for these Vote Triplers.
           </Paragraph>
           {confirmed.map((tripler, i) => (
               <TriplerRow


### PR DESCRIPTION
Once your <Link href="#/payments">payment method is set up</Link>, you’ll receive payment for these Vote Triplers.