### PR TITLE
Responsive

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,91 +1,15 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
 import { Help20, Events20, Wallet20 } from '@carbon/icons-react'
-import styled, { ThemeProvider } from 'styled-components'
-import BlockPower from '../assets/logos/block-power.png'
-import NewGeorgia from '../assets/logos/new-georgia.png'
-import { spacing, colors } from '../theme'
-
-const { REACT_APP_HEADER, REACT_APP_LOGO } = process.env
-
-const theme = {
-  dark: {
-    bgColor: colors.gray[100],
-    iconColor: colors.white,
-    iconBgHover: colors.gray[80]
-  },
-  light: {
-    bgColor: colors.white,
-    iconColor: colors.gray[100],
-    iconBgHover: colors.gray[20]
-  }
-};
-
-// FIXME: Bring in logo thru .env file and host somewhere else instead?
-let logo;
-switch (REACT_APP_LOGO) {
-  case 'block-power':
-    logo = BlockPower;
-    break;
-  case 'new-georgia':
-    logo = NewGeorgia;
-    break;
-}
-
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3rem;
-  background-color: ${props => props.theme[REACT_APP_HEADER].bgColor};
-  border-bottom: 1px solid ${ colors.gray[20] };
-  z-index: 6000;
-`;
-
-const Logo = styled.div`
-  width: ${ spacing[10] };
-  height: ${ spacing[7] };
-  margin-left: ${ spacing[3] };
-  background-image: url(${ logo });
-  background-size: contain;
-  background-repeat: no-repeat;
-  &:hover {
-    cursor: pointer;
-  }
-`
-
-const HeaderGlobalBar = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  flex: 1 1;
-  height: 100%;
-`;
-
-const HeaderGlobalAction = styled.button`
-  display: inline-block;
-  background: none;
-  padding: 0;
-  cursor: pointer;
-  width: 100%;
-  width: 3rem;
-  height: 3rem;
-  border: 0.125rem solid transparent;
-  border-bottom: 1px solid ${ colors.gray[20] };
-  transition: background-color 0.11s, border-color 0.11s;
-  & > svg {
-    fill: ${props => props.theme[REACT_APP_HEADER].iconColor}
-  }
-  &:hover {
-    background-color: ${props => props.theme[REACT_APP_HEADER].iconBgHover}
-  }
-  &:focus {
-    border-color: ${ colors.white };
-    outline: none;
-  }
-`;
+import { ThemeProvider } from 'styled-components'
+import { 
+  theme, 
+  Header, 
+  FlexContainer, 
+  Logo, 
+  HeaderGlobalBar, 
+  HeaderGlobalAction 
+} from './pageStyles'
 
 export default ({ isApproved }) => {
   const history = useHistory()
@@ -96,6 +20,7 @@ export default ({ isApproved }) => {
   return (
     <ThemeProvider theme={theme}>
       <Header aria-label="Hello Voter">
+        <FlexContainer>
         <Logo
           onClick={() => {
             redirect("/");
@@ -134,6 +59,7 @@ export default ({ isApproved }) => {
             </>
           )}
         </HeaderGlobalBar>
+        </FlexContainer>
       </Header>
     </ThemeProvider>
   );

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Column, Row, Form, Content } from 'carbon-components-react'
 import styled from 'styled-components'
 import { spacing } from '../theme'
-import Button from './Button'
 import { InlineNotification } from 'carbon-components-react'
 
 const FormStyled = styled(Form)`
@@ -15,7 +14,7 @@ const ContentContainer = styled(Content)`
 `
 
 const TitleContainer = styled(Row)`
-  margin-top: ${ spacing[5] };
+  margin-top: ${ props => props.hasHeader ? spacing[5] : spacing[7] };
   margin-bottom: ${ spacing[7] };
 `
 
@@ -32,11 +31,7 @@ const InlineNotificationStyled = styled(InlineNotification)`
   margin-bottom: ${ spacing[3] };
 `
 
-const CtaButton = styled(Button)`
-  margin-top: 0;
-`
-
-export default ({ header, title, children, submitButtonTitle, onClickSubmit, error }) => (
+export default ({ header, title, children, onClickSubmit, error }) => (
   <>
     <FormStyled onSubmit={onClickSubmit}>
       <ContentContainer>
@@ -44,7 +39,7 @@ export default ({ header, title, children, submitButtonTitle, onClickSubmit, err
           <Row>
             { header }
           </Row>
-          <TitleContainer>
+          <TitleContainer hasHeader={header !== undefined}>
             <h3>{ title }</h3>
           </TitleContainer>
           <Row style={{display: "block"}}>
@@ -62,15 +57,6 @@ export default ({ header, title, children, submitButtonTitle, onClickSubmit, err
               subtitle={error}
               title={null}
             />
-          )}
-          {submitButtonTitle && (
-              <CtaButton
-                type="submit"
-                trackingEvent={{ category: `Submit${title.replace(/ /g,'')}`, label: submitButtonTitle }}
-                isAForm
-              >
-              {submitButtonTitle}
-            </CtaButton>
           )}
         </Row>
       </CtaButtonContainer>

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -1,64 +1,42 @@
 import React from 'react'
-import { Column, Row, Form, Content } from 'carbon-components-react'
-import styled from 'styled-components'
-import { spacing } from '../theme'
-import { InlineNotification } from 'carbon-components-react'
-
-const FormStyled = styled(Form)`
-  margin-top: ${ spacing[8] };
-`
-
-const ContentContainer = styled(Content)`
-  padding: ${ spacing[3] };
-  padding-bottom: ${ spacing[10] };
-`
-
-const TitleContainer = styled(Row)`
-  margin-top: ${ props => props.hasHeader ? spacing[5] : spacing[7] };
-  margin-bottom: ${ spacing[7] };
-`
-
-const CtaButtonContainer = styled(Column)`
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  z-index: 1;
-`
-
-const InlineNotificationStyled = styled(InlineNotification)`
-  width: 100%;
-  max-width: 100%;
-  margin-bottom: ${ spacing[3] };
-`
+import { 
+  FormStyled, 
+  ContentContainer, 
+  TitleContainer, 
+  CtaButtonContainer, 
+  InlineNotificationStyled,
+  Container,
+  ResponsiveContainer
+} from './pageStyles'
 
 export default ({ header, title, children, onClickSubmit, error }) => (
   <>
     <FormStyled onSubmit={onClickSubmit}>
       <ContentContainer>
-        <Column lg={{ span: 4, offset: 3 }} md={{ span: 4, offset: 1 }} sm={{ span: 4 }}>
-          <Row>
+        <Container>
+          <ResponsiveContainer>
+          <div>
             { header }
-          </Row>
+          </div>
           <TitleContainer hasHeader={header !== undefined}>
             <h3>{ title }</h3>
           </TitleContainer>
-          <Row style={{display: "block"}}>
+          <div>
             { children }
-          </Row>
-        </Column>
+          </div>
+          </ResponsiveContainer>
+        </Container>
       </ContentContainer>
       <CtaButtonContainer lg={{ span: 4, offset: 3 }} md={{ span: 4, offset: 1 }} sm={{ span: 4 }}>
-        <Row>
-          {error && (
-            <InlineNotificationStyled
-              hideCloseButton
-              kind="error"
-              icondescription="Dismiss notification"
-              subtitle={error}
-              title={null}
-            />
-          )}
-        </Row>
+        {error && (
+          <InlineNotificationStyled
+            hideCloseButton
+            kind="error"
+            icondescription="Dismiss notification"
+            subtitle={error}
+            title={null}
+          />
+        )}
       </CtaButtonContainer>
     </FormStyled>
   </>

--- a/src/components/SignUp/ContactInfoPage.js
+++ b/src/components/SignUp/ContactInfoPage.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { spacing } from '../../theme'
 import PageLayout from '../PageLayout'
-import Breadcrumbs from '../Breadcrumbs'
+import Button from '../Button'
 import AddressForm from '../AddressForm'
 import { FormGroup, TextInput } from 'carbon-components-react'
 import { useHistory } from 'react-router-dom'
@@ -45,7 +45,6 @@ export const ContactInfoPage = () => {
     <PageLayout
       error={err}
       title="Please Enter Your Details"
-      submitButtonTitle="Submit"
       onClickSubmit={(e) => {
         e.preventDefault()
         const formData = new FormData(e.target)
@@ -114,6 +113,13 @@ export const ContactInfoPage = () => {
           />
         </Row>
       </FormGroup>
+      <Button 
+        type="submit"
+        trackingEvent={{ category: 'SubmitSignupInfo', label: 'Submit'}}
+        isAForm
+      >
+        Submit
+      </Button>
     </PageLayout>
   )
 }

--- a/src/components/Triplers/ConfirmPage.js
+++ b/src/components/Triplers/ConfirmPage.js
@@ -113,14 +113,22 @@ const ConfirmPage = ({ tripler, confirmTriplers, loading }) => {
         title={null}
       />
       }
-      <Button type="submit"
-              loading={loading}
-              trackingEvent={{ category: 'SubmitTriplerConfirm', label: 'Add'}}
-              isAForm
-        >Add</Button>
-      <Button small kind="tertiary" href={'/triplers'}
+      <Button 
+        type="submit"
+        loading={loading}
+        trackingEvent={{ category: 'SubmitTriplerConfirm', label: 'Add'}}
+        isAForm
+      >
+        Add
+      </Button>
+      <Button 
+        small 
+        kind="tertiary" 
+        href={'/triplers'}
         trackingEvent={{ category: 'BackFromTriplerConfirm', label: 'Go back to My Vote Triplers'}}
-        >Go back to My Vote Triplers</Button>
+      >
+        Go back to My Vote Triplers
+      </Button>
     </PageLayout>
   )
 }

--- a/src/components/pageStyles.js
+++ b/src/components/pageStyles.js
@@ -1,0 +1,101 @@
+import styled from "styled-components";
+import { spacing, colors, breakpoints } from "../theme";
+import BlockPower from '../assets/logos/block-power.png'
+import NewGeorgia from '../assets/logos/new-georgia.png'
+
+const { REACT_APP_HEADER, REACT_APP_LOGO } = process.env
+
+// FIXME: Bring in logo thru .env file and host somewhere else instead?
+let logo;
+switch (REACT_APP_LOGO) {
+  case 'block-power':
+    logo = BlockPower;
+    break;
+  case 'new-georgia':
+    logo = NewGeorgia;
+    break;
+}
+
+export const theme = {
+  dark: {
+    bgColor: colors.gray[100],
+    iconColor: colors.white,
+    iconBgHover: colors.gray[80]
+  },
+  light: {
+    bgColor: colors.white,
+    iconColor: colors.gray[100],
+    iconBgHover: colors.gray[20]
+  }
+};
+
+export const Header = styled.header`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3rem;
+  background-color: ${props => props.theme[REACT_APP_HEADER].bgColor};
+  border-bottom: 1px solid ${ colors.gray[20] };
+  z-index: 6000;
+`;
+
+export const Logo = styled.div`
+  width: ${ spacing[10] };
+  height: ${ spacing[7] };
+  margin-left: ${ spacing[3] };
+  background-image: url(${ logo });
+  background-size: contain;
+  background-repeat: no-repeat;
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+export const HeaderGlobalBar = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  flex: 1 1;
+  height: 100%;
+`;
+
+export const HeaderGlobalAction = styled.button`
+  display: inline-block;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  width: 100%;
+  width: 3rem;
+  height: 3rem;
+  border: 0.125rem solid transparent;
+  border-bottom: 1px solid ${ colors.gray[20] };
+  transition: background-color 0.11s, border-color 0.11s;
+  & > svg {
+    fill: ${props => props.theme[REACT_APP_HEADER].iconColor}
+  }
+  &:hover {
+    background-color: ${props => props.theme[REACT_APP_HEADER].iconBgHover}
+  }
+  &:focus {
+    border-color: ${ colors.white };
+    outline: none;
+  }
+`;
+
+export const Container = styled.div`
+  max-width: ${breakpoints.lg.width};
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  /* @media (max-width: ${breakpoints.lg.width}) {
+  } */
+`;
+
+export const FlexContainer = styled.div`
+  max-width: ${breakpoints.lg.width};
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  align-items: center;
+`

--- a/src/components/pageStyles.js
+++ b/src/components/pageStyles.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Column, Row, Form, Content, InlineNotification } from 'carbon-components-react'
 import { spacing, colors, breakpoints } from "../theme";
 import BlockPower from '../assets/logos/block-power.png'
 import NewGeorgia from '../assets/logos/new-georgia.png'
@@ -82,15 +83,6 @@ export const HeaderGlobalAction = styled.button`
   }
 `;
 
-export const Container = styled.div`
-  max-width: ${breakpoints.lg.width};
-  width: 100%;
-  margin-left: auto;
-  margin-right: auto;
-  /* @media (max-width: ${breakpoints.lg.width}) {
-  } */
-`;
-
 export const FlexContainer = styled.div`
   max-width: ${breakpoints.lg.width};
   width: 100%;
@@ -98,4 +90,50 @@ export const FlexContainer = styled.div`
   margin-right: auto;
   display: flex;
   align-items: center;
+`
+
+export const Container = styled.div`
+  max-width: ${breakpoints.lg.width};
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: ${ spacing[3] };
+  padding-right: ${ spacing[3] };
+`;
+
+export const ResponsiveContainer = styled.div`
+  width: 50%;
+  @media (max-width: ${breakpoints.lg.width}) {
+    width: 60%
+  };
+  @media (max-width: ${breakpoints.md.width}) {
+    width: 100%
+  };
+`
+
+export const FormStyled = styled(Form)`
+  margin-top: ${ spacing[8] };
+`
+
+export const ContentContainer = styled(Content)`
+  padding: ${ spacing[3] };
+  padding-bottom: ${ spacing[10] };
+`
+
+export const TitleContainer = styled.div`
+  margin-top: ${ props => props.hasHeader ? spacing[5] : spacing[7] };
+  margin-bottom: ${ spacing[7] };
+`
+
+export const CtaButtonContainer = styled(Column)`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+`
+
+export const InlineNotificationStyled = styled(InlineNotification)`
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: ${ spacing[3] };
 `

--- a/src/stories/Signup.stories.js
+++ b/src/stories/Signup.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Menu from "../components/Menu";
 import { LogIn } from "../components/Login";
-import { SignUpPage } from "../components/SignUp/SignUpPage";
+import { ContactInfoPage } from "../components/SignUp/ContactInfoPage";
 import PendingApprovalPage from '../components/PendingApprovalPage'
 
 export default {
@@ -15,10 +15,10 @@ export const LoginPage = () => (
   </>
 );
 
-export const SignUp = () => (
+export const SignUpPage = () => (
   <>
     <Menu isApproved={false} />
-    <SignUpPage />
+    <ContactInfoPage />
   </>
 );
 

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -5,6 +5,47 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Convert
+// Default, Use with em() and rem() functions
+export const baseFontSize = 16;
+
+/**
+ * Convert a given px unit to a rem unit
+ * @param {number} px
+ * @returns {string}
+ */
+export function rem(px) {
+  return `${px / baseFontSize}rem`;
+}
+
+export const breakpoints = {
+  sm: {
+    width: rem(320),
+    columns: 4,
+    margin: '0',
+  },
+  md: {
+    width: rem(672),
+    columns: 8,
+    margin: rem(16),
+  },
+  lg: {
+    width: rem(1056),
+    columns: 16,
+    margin: rem(16),
+  },
+  xlg: {
+    width: rem(1312),
+    columns: 16,
+    margin: rem(16),
+  },
+  max: {
+    width: rem(1584),
+    columns: 16,
+    margin: rem(24),
+  },
+};
+
 export const spacing = [
   '0px', // 0
   '2px', // 1


### PR DESCRIPTION
for first pass at responsive layout — put navigation and content in a max-width container so that navigation logo and content can be lined up

@litenull can you take a look let me know if that messes anything? moved the submit button out of `PageLayout` and directly into `ContactInfoPage`. also `ContactInfoPage` and `Triplers/ConfirmPage` were the pages with forms that might be compromised i didnt check. we prob want to take out Form and InlineNotification from `PageLayout` as well?

![image](https://user-images.githubusercontent.com/13405391/89665833-e82e4400-d89e-11ea-9675-278c87ca707f.png)
![image](https://user-images.githubusercontent.com/13405391/89665868-f714f680-d89e-11ea-8288-109230fa58b9.png)
![image](https://user-images.githubusercontent.com/13405391/89665898-03994f00-d89f-11ea-9ba1-d329861a5160.png)
![image](https://user-images.githubusercontent.com/13405391/89665961-262b6800-d89f-11ea-83a2-e06a67e69b91.png)
![image](https://user-images.githubusercontent.com/13405391/89666001-38a5a180-d89f-11ea-8cb8-5459281f3cbe.png)
![image](https://user-images.githubusercontent.com/13405391/89666034-49eeae00-d89f-11ea-90a9-7437499eea68.png)
![image](https://user-images.githubusercontent.com/13405391/89666074-5d9a1480-d89f-11ea-9c22-529f0eee5b92.png)