### PR TITLE
Tripler table ux

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { DataTable, Pagination } from 'carbon-components-react'
 import { AddAlt16 } from '@carbon/icons-react'
-import { spacing } from '../theme'
+import { spacing, colors } from '../theme'
 
 const {
   TableContainer,
@@ -25,6 +25,22 @@ const TableContainerStyled = styled(TableContainer)`
   min-width: 0;
   width: 100%;
   margin-top: ${ spacing[7] };
+  overflow: visible;
+`
+
+const TableToolbarContainer = styled.div`
+  position: sticky;
+  top: 48px;
+  z-index: 1;
+`
+
+const TableTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding-left: ${ spacing[5] };
+  background-color: ${ colors.gray[20] };
+  width: 100%;
+  font-weight: 600;
 `
 
 // FIXME: Hacked styling to make text centered in cell
@@ -53,33 +69,23 @@ const renderTable = (batchActionClick) => (
     getTableContainerProps,
   }) => (
     <TableContainerStyled {...getTableContainerProps()}>
-      <TableToolbar {...getToolbarProps()}>
-        <TableBatchActions {...getBatchActionProps()}>
-          <TableBatchAction
-            renderIcon={AddAlt16}
-            iconDescription="Download the selected rows"
-            onClick={batchActionClick(selectedRows)}
-          >
-            Add
-        </TableBatchAction>
-        </TableBatchActions>
-        {/* <TableToolbarContent>
-          <TableToolbarSearch onChange={onInputChange} />
-        </TableToolbarContent> */}
-      </TableToolbar>
+      <TableToolbarContainer>
+        <TableToolbar {...getToolbarProps()}>
+          <TableBatchActions {...getBatchActionProps()}>
+            <TableBatchAction
+              renderIcon={AddAlt16}
+              iconDescription="Download the selected rows"
+              onClick={batchActionClick(selectedRows)}
+            >
+              Add
+            </TableBatchAction>
+          </TableBatchActions>
+          <TableTitleContainer>
+            Eligible People
+          </TableTitleContainer>
+        </TableToolbar>
+      </TableToolbarContainer>
       <Table {...getTableProps()} size='tall'>
-        <TableHead>
-          <TableRow>
-            <div style={{ visibility: "hidden" }}>
-              <TableSelectAll {...getSelectionProps()} />
-            </div>
-            {headers.map((header) => (
-              <TableHeader {...getHeaderProps({ header })}>
-                {header.header}
-              </TableHeader>
-            ))}
-          </TableRow>
-        </TableHead>
         <TableBody>
           {rows.map((row) => (
             <TableRow key={row.id} {...getRowProps({ row })}>
@@ -93,22 +99,6 @@ const renderTable = (batchActionClick) => (
           ))}
         </TableBody>
       </Table>
-      <Pagination
-        backwardText="Previous page"
-        forwardText="Next page"
-        itemsPerPageText="Show:"
-        page={1}
-        pageNumberText="Page Number"
-        pageSize={10}
-        pageSizes={[
-          10,
-          20,
-          30,
-          40,
-          50
-        ]}
-        totalItems={rows.length}
-      />
     </TableContainerStyled>
   );
 

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { createGlobalStyle } from 'styled-components'
 import { DataTable, Pagination } from 'carbon-components-react'
 import { AddAlt16 } from '@carbon/icons-react'
 import { spacing, colors } from '../theme'
@@ -54,6 +54,13 @@ const TableSelectRowStyled = styled(TableSelectRow)`
   width: ${ spacing[5] };
 `
 
+// FIXME: Hide `x Selected` summary in data table when counting row selection
+const TableBatchActionsHack = createGlobalStyle`
+  #data-table .bx--batch-summary {
+    visibility: hidden;
+  }
+`
+
 const renderTable = (batchActionClick) => (
   {
     rows,
@@ -71,13 +78,14 @@ const renderTable = (batchActionClick) => (
     <TableContainerStyled {...getTableContainerProps()}>
       <TableToolbarContainer>
         <TableToolbar {...getToolbarProps()}>
-          <TableBatchActions {...getBatchActionProps()}>
+          <TableBatchActionsHack />
+          <TableBatchActions id="data-table" {...getBatchActionProps()}>
             <TableBatchAction
               renderIcon={AddAlt16}
               iconDescription="Download the selected rows"
               onClick={batchActionClick(selectedRows)}
             >
-              Add
+              Add {selectedRows.length} Tripler(s) to my list
             </TableBatchAction>
           </TableBatchActions>
           <TableTitleContainer>

--- a/src/stories/Triplers.stories.js
+++ b/src/stories/Triplers.stories.js
@@ -147,7 +147,7 @@ export const AddPage = () => (
         {
           id: "a",
           name: "Judy Blume",
-          address: "1 Really Good Address Ln asdasdsa as das dasd ",
+          address: "1 Really Long Address Ln Lorem Ipsum Lorem Ipsum",
         },
         {
           id: "b",
@@ -155,55 +155,124 @@ export const AddPage = () => (
           address: "1 Good Boy Rd",
         },
         {
-          id: "d",
+          id: "c",
           name: "Lauren Ralph",
           address: "1 Road Rd",
         },
         {
+          id: "d",
+          name: "Pamela Jones",
+          address: "1 Jones Road Rd",
+        },
+        {
           id: "e",
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          name: "Torr Carbin",
+          address: "31 Autumn Leaf Avenue",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "f",
+          name: "Stepha Gleadhell",
+          address: "1716 Warner Drive",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "g",
+          name: "Charmaine Kilalea",
+          address: "378 Carey Alley",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "h",
+          name: "Janeczka Pauletto",
+          address: "16 Lukken Trail",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "i",
+          name: "Guthry Ondrich",
+          address: "7673 Moose Parkway",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "j",
+          name: "Nils Aspinall",
+          address: "4 Mendota Plaza",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "k",
+          name: "Vaclav Comolli",
+          address: "186 Dryden Pass",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
-        },
-
-        {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "l",
+          name: "Xylina Blakey",
+          address: "23824 Toban Lane",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "m",
+          name: "Tann Robrow",
+          address: "49337 Waywood Circle",
         },
         {
-          name: "Pamela Jones",
-          address: "1 Jones Road Rd",
+          id: "n",
+          name: "Gretchen Kenningham",
+          address: "3599 Declaration Center",
+        },
+        {
+          id: "o",
+          name: "Karel Colledge",
+          address: "23602 Myrtle Circle",
+        },
+        {
+          id: "p",
+          name: "Tremain Greenhouse",
+          address: "3 Leroy Plaza",
+        },
+        {
+          id: "q",
+          name: "Venita Perryn",
+          address: "5 Judy Pass",
+        },
+        {
+          id: "r",
+          name: "Neal Cherrett",
+          address: "6 Merrick Road",
+        },
+        {
+          id: "s",
+          name: "Abagail Kershaw",
+          address: "2 Merrick Park",
+        },
+        {
+          id: "t",
+          name: "Vidovik Michelotti",
+          address: "7899 David Junction",
+        },
+        {
+          id: "u",
+          name: "Clyve Tirrell",
+          address: "21357 Brentwood Crossing",
+        },
+        {
+          id: "v",
+          name: "Jeannine O'Loinn",
+          address: "86170 Mifflin Terrace",
+        },
+        {
+          id: "w",
+          name: "Alaric Musselwhite",
+          address: "05 Weeping Birch Drive",
+        },
+        {
+          id: "x",
+          name: "Trefor Merit",
+          address: "1 Surrey Road",
+        },
+        {
+          id: "y",
+          name: "Ramon Breed",
+          address: "85 Kipling Terrace",
+        },
+        {
+          id: "z",
+          name: "Joann Pawden",
+          address: "2 Hollow Ridge Parkway",
         },
       ]}
     />


### PR DESCRIPTION
While I was in the AddTripler / DataTable files, saw some quick UX opportunities:

1. Table Header sticky and fixed to top when scrolling
2. Remove Pagination (Noticing on Carbon repo: `This component is *experimental* and may change.`) — think the sticky header would fix the same problem pagination would be solving. Also, Plaid designs call for infinite scroll over pagination.
3. Changed copywriting for adding Tripler button from `Add` to `Add {x} Triplers to my list`

![Add Tripler Table UX](https://user-images.githubusercontent.com/13405391/90152269-3fc02a00-dd4d-11ea-956e-94e4dfaecf21.gif)
