### PR TITLE
Update help page env variables

### DIFF
--- a/src/components/Help/HelpPage.js
+++ b/src/components/Help/HelpPage.js
@@ -10,34 +10,7 @@ const TopParagraph = styled.p`
   margin-bottom: ${ spacing[7]};
 `
 
-// FIXME: have separate .env variables for REACT_APP_HELP_URL, REACT_APP_HELP_TITLE, REACT_APP_HELP_EMAIL  
-const { REACT_APP_ORG } = process.env;
-
-let url;
-let title;
-let email;
-switch (REACT_APP_ORG) {
-  case 'BlockPower':
-    url = "https://www.blockpower.vote/faq-blockpower";
-    title = "BlockPower Support";
-    email = "support+bp@blockpower.vote";
-    break;
-  case 'NGP':
-    url = "https://www.blockpower.vote/ngp/faq-ngp";
-    title = "New Georgia Project Support";
-    email = "support+ngp@blockpower.vote";
-    break;
-  case 'ColorOfChange':
-    url = "https://www.blockpower.vote/coc-pac/faq-coc-pac";
-    title = "Color of Change Support";
-    email = "support+coc@blockpower.vote";
-    break;
-  case 'Bloc':
-    url = "https://blockpower.vote/blocbybloc/faq-blocbybloc";
-    title = "BLOC Support";
-    email = "support+bloc@blockpower.vote";
-    break;
-}
+const { REACT_APP_HELP_URL, REACT_APP_HELP_TITLE, REACT_APP_HELP_EMAIL } = process.env;
 
 export default () => (
   <PageLayout title="Help">
@@ -48,15 +21,15 @@ export default () => (
       title="FAQ"
       description="See answers to common questions asked by other Voting Ambassadors"
       onClick={() => {
-        window.open(url, "_blank")
+        window.open(REACT_APP_HELP_URL, "_blank")
       }}
     />
     <CardButton
       icon={<Partnership24 />}
-      title={title}
-      description={email}
+      title={REACT_APP_HELP_TITLE}
+      description={REACT_APP_HELP_EMAIL}
       onClick={() => {
-        window.open(`mailto:${email}`);
+        window.open(`mailto:${REACT_APP_HELP_EMAIL}`);
       }}
     />
     <CardButton


### PR DESCRIPTION
`REACT_APP_HELP_URL` — example: "https://www.blockpower.vote/faq-blockpower"
`REACT_APP_HELP_TITLE` — example: "BlockPower Support"
`REACT_APP_HELP_EMAIL` — example: "support+bloc@blockpower.vote"

might also be able to remove `REACT_APP_ORG` when https://github.com/colab-coop/hello-voter/pull/99 is merged in 
