### PR TITLE
Fix signout redirect on staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 REACT_APP_ORGID=VT6WX8A
 REACT_APP_AUDIANCE=blockpower.us
-REACT_APP_BASEURI=/voterambassador/staging
-REACT_APP_APPPATH=voterambassador/staging
+# The URL path to the app root on this server.
+REACT_APP_APP_PATH=/
 REACT_APP_API_DOMAIN=gotv-vt.ourvoiceusa.org
 REACT_APP_API_SSL=true
 REACT_APP_OAUTH_HEADER=x-sm-oauth-url

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -19,7 +19,7 @@ import {
 } from './pageStyles'
 import { AppContext } from '../api/AppContext';
 
-const { REACT_APP_PAYMENT_FEATURE } = process.env
+const { REACT_APP_PAYMENT_FEATURE, REACT_APP_APP_PATH } = process.env
 
 export default ({ isApproved }) => {
   const [navOpen, setNavOpen] = useState(false)
@@ -32,7 +32,7 @@ export default ({ isApproved }) => {
   const signOut = () => {
     // Fully clear data and refresh the webpage.
     localStorage.clear();
-    window.location = "/";
+    window.location = REACT_APP_APP_PATH || "/";
   }
 
   return (


### PR DESCRIPTION
You'll just need to set `REACT_APP_APP_PATH=/blockpower` on staging. It should default to `/` like this for local development.