### PR TITLE
Hide "Vote Triplers" and "Payments" on mobile when not approved

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -122,14 +122,16 @@ const Menu = ({ isApproved }) => {
             <SwitcherItemStyled onClick={() => {redirect("/")}}>
               Home
             </SwitcherItemStyled>
-            <SwitcherItemStyled onClick={() => {redirect("/triplers")}}>
-              Vote Triplers
-            </SwitcherItemStyled>
+            {isApproved &&
+              <SwitcherItemStyled onClick={() => {redirect("/triplers")}}>
+                Vote Triplers
+              </SwitcherItemStyled>
+            }
             {/*
               FIXME: Hide payments `REACT_APP_NONVOLUNTEER_PAYMENT_FEATURE` & `REACT_APP_PAYMENT_FEATURE`
               with Boolean rather than "true" and empty .env field
             */}
-            {REACT_APP_PAYMENT_FEATURE &&
+            {isApproved && REACT_APP_PAYMENT_FEATURE &&
               <SwitcherItemStyled onClick={() => {redirect("/payments")}}>
                 Payments
               </SwitcherItemStyled>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -24,7 +24,7 @@ import { AppContext } from '../api/AppContext';
 
 const { REACT_APP_PAYMENT_FEATURE, REACT_APP_APP_PATH } = process.env
 
-export default ({ isApproved }) => {
+const Menu = ({ isApproved }) => {
   const [navOpen, setNavOpen] = useState(false)
   const [profileNavOpen, setProfileNavOpen] = useState(false)
   const history = useHistory()
@@ -152,3 +152,5 @@ export default ({ isApproved }) => {
     </ThemeProvider>
   );
 };
+
+export default Menu;


### PR DESCRIPTION
Should hide the "Vote Tripers" and "Payments" buttons from the mobile menu when the user is not approved or not logged in

![Screen Shot 2020-10-18 at 12 24 48 PM](https://user-images.githubusercontent.com/1656829/96376571-0d5fee00-113d-11eb-87f3-9a5a937d5660.png)

