### PR TITLE
Enable mock data by default in .env.example; add advice to unset HOST to the setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
+# This enables use of mock data for local development, instead of accessing
+# data at the REACT_APP_API_URL.  To disable, comment out this line.
+REACT_APP_FORCE_MOCK_DATA=true
+
+# URL to the backend.  REACT_APP_FORCE_MOCK_DATA=true overrides this setting.
+REACT_APP_API_URL=https://blockpower.stage2.api.blockpower.vote
+
 REACT_APP_ORGID=VT6WX8A
 REACT_APP_AUDIANCE=blockpower.us
 # The URL path to the app root on this server.
@@ -8,11 +15,6 @@ REACT_APP_OAUTH_HEADER=x-sm-oauth-url
 REACT_APP_TOKEN_KEY=token
 REACT_APP_KEY=auth
 REACT_APP_DEVELOPMENT=true
-REACT_APP_API_URL=https://blockpower.stage.api.blockpower.vote
-
-# If set, targets the local mock data instead of REACT_APP_API_URL.
-# Note: to disable, leave this value empty or commented out, do not set to "false".
-# REACT_APP_FORCE_MOCK_DATA=
 
 REACT_APP_ORG="BlockPower"
 REACT_APP_HEADER=dark

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Once the Ambassador has "claimed" one or more Vote Triplers, they can contact th
 
 ### Installation
 
-1. Copy `.env.example` to `.env` and modify as needed: `cp .env.example .env`**See documentation on Environment Variables below**
-   **If you want to use mock data offline, add the env var: `REACT_APP_FORCE_MOCK_DATA=true`
-   **If you want to target staging data, then don’t include `REACT_APP_FORCE_MOCK_DATA=`and ensure the REACT_APP_API_URL is set to the stage api url: `REACT_APP_API_URL=https://blockpower.stage2.api.blockpower.vote`
+1. Copy `.env.example` to `.env` and modify as needed: `cp .env.example .env` (for details, see the **Environment Variables** section below)
 2. Install dependencies: `npm install`
-3. Start the server: `npm start`
+3. Make sure your `HOST` environment variable is unset, or set to `localhost`.
+4. Start the server: `npm start`
+5. You should now be able to visit your local front-end at http://localhost:3000/
 
 Optionally,
 


### PR DESCRIPTION
Hi!  We were having a few speed bumps getting new devs started; these are tweaks to smooth out the setup process for future devs.