### PR TITLE
Show the PayPal account button, only if the user has paypal_approved set.

### DIFF
--- a/src/components/Payments/AddPage.js
+++ b/src/components/Payments/AddPage.js
@@ -6,6 +6,7 @@ import PageLayout from "../PageLayout";
 import CardButton from "../CardButton";
 import Breadcrumbs from "../Breadcrumbs";
 import chime from "../../assets/images/chime.png";
+import paypal from "../../assets/images/paypal.png";
 import { usePlaidLink } from "react-plaid-link";
 import { AppContext } from "../../api/AppContext";
 import { useHistory } from "react-router-dom";
@@ -73,6 +74,19 @@ export const AddPage = ({
         <Details>You already have selected a payment method.</Details>
       )}
       <GridThreeUp>
+        {
+          user.paypal_approved &&
+          <CardButton
+            icon={<CardIcon src={paypal} />}
+            title="Use PayPal"
+            description="Get set up quickly to receive payments with PayPal."
+            onClick={(e) => {
+              e.preventDefault();
+              history.push("/payments/paypal");
+            }}
+            disabled={alreadyHasPayoutProvider}
+          />
+        }
         <CardButton
           icon={<Finance24 />}
           title="Link bank account"

--- a/src/components/Payments/PayPalPage.js
+++ b/src/components/Payments/PayPalPage.js
@@ -50,6 +50,12 @@ export default () => {
     history.push("/payments");
   };
 
+  if (!user.paypal_approved) {
+    // Reject users that don't have the paypal_approved flag.
+    history.push("/payments");
+    return null;
+  }
+
   return (
     <PageLayout
       title={""}


### PR DESCRIPTION
Implements https://www.pivotaltracker.com/n/projects/2476452/stories/175920208.

If `paypal_approved` is not present (and true) on the user object, the PayPal button doesn't appear and any attempt to navigate to `/payments/paypal` is rejected.