### PR TITLE
Make the signup form prefillable.

### DIFF
--- a/src/components/Profile/AddressForm.js
+++ b/src/components/Profile/AddressForm.js
@@ -48,7 +48,7 @@ export default ({ ambassador }) => (
         name="address1"
         invalidText="Invalid error message."
         labelText="Street Address*"
-        defaultValue={ambassador.address.address1}
+        defaultValue={ambassador.address?.address1}
         required
       />
     </FormGroup>
@@ -60,7 +60,7 @@ export default ({ ambassador }) => (
             name="city"
             invalidText="Invalid error message."
             labelText="City*"
-            defaultValue={ambassador.address.city}
+            defaultValue={ambassador.address?.city}
             required
           />
         </RowLeft>
@@ -70,7 +70,7 @@ export default ({ ambassador }) => (
             name="state"
             invalidText="Invalid error message."
             labelText="State*"
-            defaultValue={ambassador.address.state}
+            defaultValue={ambassador.address?.state}
             required
           />
         </RowCenter>
@@ -80,7 +80,7 @@ export default ({ ambassador }) => (
             name="zip"
             invalidText="Invalid error message."
             labelText="ZIP Code*"
-            defaultValue={ambassador.address.zip}
+            defaultValue={ambassador.address?.zip}
             required
           />
         </RowRight>

--- a/src/components/Profile/ContactInfoPage.js
+++ b/src/components/Profile/ContactInfoPage.js
@@ -14,12 +14,17 @@ import AddressForm from "./AddressForm";
 import { useHistory } from "react-router-dom";
 import { AppContext } from "../../api/AppContext";
 import NoNewSignupsPage from "./NoNewSignupsPage";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 
 const Row = styled.div`
   display: grid;
   grid-auto-columns: 1fr;
   grid-column-gap: ${spacing[5]};
   grid-template-columns: 1fr 1fr;
+
+  div {
+    grid-column-end: unset;
+  }
 `;
 
 const Divider = styled.div`
@@ -96,6 +101,27 @@ export const ContactInfoPage = ({ ambassador, setAmbassador, err, disablePhone, 
             </Row>
           </FormGroup>
           <FormGroup legendText="">
+            <TextInput
+              id="phone"
+              name="phone"
+              invalidText="Invalid error message."
+              labelText="Phone number*"
+              defaultValue={ambassador.phone}
+              required
+              disabled={disablePhone}
+            />
+          </FormGroup>
+          <FormGroup legendText="">
+            <TextInput
+              id="email"
+              name="email"
+              invalidText="Invalid error message."
+              labelText="Email"
+              required
+              defaultValue={ambassador.email}
+            />
+          </FormGroup>
+          <FormGroup legendText="">
             <Row>
               <TextInput
                 id="date_of_birth"
@@ -110,29 +136,6 @@ export const ContactInfoPage = ({ ambassador, setAmbassador, err, disablePhone, 
           </FormGroup>
           <Divider />
           <AddressForm ambassador={ambassador} />
-          <Divider />
-          <FormGroup legendText="">
-            <TextInput
-              id="email"
-              name="email"
-              invalidText="Invalid error message."
-              labelText="Email*"
-              defaultValue={ambassador.email}
-              required
-              disabled={disableEmail}
-            />
-          </FormGroup>
-          <FormGroup legendText="">
-            <TextInput
-              id="phone"
-              name="phone"
-              invalidText="Invalid error message."
-              labelText="Phone number*"
-              defaultValue={ambassador.phone}
-              required
-              disabled={disablePhone}
-            />
-          </FormGroup>
           <SubmissionContainer>
             {err && (
               <InlineNotificationStyled
@@ -229,11 +232,13 @@ export const ProfilePageSignup = () => {
   const { ambassador, setAmbassador, api, fetchUser, user } = React.useContext(
     AppContext
   );
+  const [signupPrefill, setSignupPrefill] = useLocalStorage("signup_prefill", {});
 
   user &&
     user.signup_completed &&
     user.onboarding_completed &&
     history.push("/");
+
   useEffect(() => {
     const signup = async () => {
       console.log("Signing up");
@@ -241,19 +246,23 @@ export const ProfilePageSignup = () => {
       if (error) return setErr(error.msg);
       const { userError } = await fetchUser();
       if (userError) return setErr(userError.msg);
+      setSignupPrefill({});  // clean up upon successful signup
     };
     if (ambassador.signupComplete) {
       signup();
     }
   }, [ambassador]);
 
-
-if (user && user.msg==="Your account is locked.") {
+  if (user && user.msg === "Your account is locked.") {
     return <DeniedPage/>
   }
+
+  const formDefaults = {};
+
+
   return (
     <ContactInfoPage
-      ambassador={ambassador}
+      ambassador={{...ambassador, ...signupPrefill}}
       setAmbassador={setAmbassador}
       err={err}
     />

--- a/src/router.js
+++ b/src/router.js
@@ -4,6 +4,7 @@ import { HashRouter, Route, Switch, Redirect } from "react-router-dom";
 import { AppProvider, AppContext } from "./api/AppContext";
 
 import { initAnalytics, useAnalytics } from "./hooks/useAnalytics";
+import { useLocalStorage } from "./hooks/useLocalStorage";
 
 import Menu from "./components/Menu";
 import Footer from "./components/Footer";
@@ -90,8 +91,23 @@ const AuthPublicRoute = ({ component: Component, authenticated, path }) => (
 
 const AppRoutes = () => {
   const { authenticated, loading, user } = React.useContext(AppContext);
+  const [ signupPrefill, setSignupPrefill ] = useLocalStorage("signup_prefill", {});
   useAnalytics();
   if (loading) return <Loading />;
+
+  const fragment = decodeURIComponent(window.location.hash);
+  const prefillMatch = fragment.match(/^\W*prefill=(.*)/);
+  if (prefillMatch) {
+    let prefill = {};
+    try {
+      prefill = JSON.parse(prefillMatch[1]);
+    } catch (err) {
+      console.log('Invalid JSON: ', prefillMatch[1]);
+    }
+    setSignupPrefill(prefill);
+    window.location.hash = '';
+  }
+
   return (
     <div style={{ position: "relative", minHeight: "100vh" }}>
       <Menu isApproved={user && user.approved} />


### PR DESCRIPTION
This implements prefilling in two steps:

1. `router.js` checks to see if the URL fragment consists of `prefill=` followed by a JSON object.  If this is present, the JSON object will be parsed and stored in localStorage under the key `signup_prefill`, and then the fragment identifier will be cleared.

2. `ProfilePageSignup` gets the `signup_prefill` item from localStorage, and uses it to set the defaults for the fields in the signup form.  Once the signup form is submitted successfully, the `signup_prefill` item in localStorage is cleared.

According to the URL specification, the fragment identifier is not included as part of the HTTP request.  Thus, the prefill data never leaves the browser and cannot be intercepted on any network.

The prefill data is placed in localStorage instead of leaving it in the fragment identifier so that the prefill data doesn't end up in the user's bookmarks.