### PR TITLE
Fixes for off-ramp states and pages (unapproved, locked, signups closed)

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -22,7 +22,7 @@ const errorHandler = (e) => {
 }
 
 const isFailStatusCode = (status) => {
-  return [404, 401, 400, 500].includes(status)
+  return [400, 401, 403, 404, 500].includes(status)
 }
 
 export const getToken = () => {

--- a/src/components/LockedPage.js
+++ b/src/components/LockedPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import PageLayout from "./PageLayout";
+import { ResponsiveContainer } from './pageStyles';
+
+export default () => (
+  <PageLayout title="Your account needs further review">
+    <ResponsiveContainer>
+      <p>
+        To start the review process, please visit this link to provide more information: <a href="https://blockpower.link/manualreview">
+          https://blockpower.link/manualreview
+        </a>
+      </p>
+    </ResponsiveContainer>
+  </PageLayout>
+);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -24,11 +24,13 @@ import { AppContext } from '../api/AppContext';
 
 const { REACT_APP_PAYMENT_FEATURE } = process.env;
 
-const Menu = ({ isApproved }) => {
+const Menu = () => {
   const [navOpen, setNavOpen] = useState(false)
   const [profileNavOpen, setProfileNavOpen] = useState(false)
   const history = useHistory()
   const { user, authenticated, signOut } = React.useContext(AppContext)
+  const approved = user?.approved && !(user?.locked);
+
   const redirect = async (href) => {
     setNavOpen(false)
     setProfileNavOpen(false)
@@ -44,7 +46,7 @@ const Menu = ({ isApproved }) => {
             redirect("/");
           }}
         />
-        {isApproved && (
+        {approved && (
           <HeaderNavigationStyled
             aria-label="Menu"
           >
@@ -102,7 +104,7 @@ const Menu = ({ isApproved }) => {
         <HeaderPanelRightContainer navOpen={profileNavOpen}>
           <HeaderPanelSpacer />
           <SwitcherStyledRight>
-            {user &&
+            {approved &&
               <SwitcherItemStyled onClick={() => {redirect("/profile")}}>
                 Profile
               </SwitcherItemStyled>
@@ -119,7 +121,7 @@ const Menu = ({ isApproved }) => {
             <SwitcherItemStyled onClick={() => {redirect("/")}}>
               Home
             </SwitcherItemStyled>
-            {isApproved &&
+            {approved &&
               <SwitcherItemStyled onClick={() => {redirect("/triplers")}}>
                 Vote Triplers
               </SwitcherItemStyled>
@@ -128,7 +130,7 @@ const Menu = ({ isApproved }) => {
               FIXME: Hide payments `REACT_APP_NONVOLUNTEER_PAYMENT_FEATURE` & `REACT_APP_PAYMENT_FEATURE`
               with Boolean rather than "true" and empty .env field
             */}
-            {isApproved && REACT_APP_PAYMENT_FEATURE &&
+            {approved && REACT_APP_PAYMENT_FEATURE &&
               <SwitcherItemStyled onClick={() => {redirect("/payments")}}>
                 Payments
               </SwitcherItemStyled>
@@ -137,7 +139,7 @@ const Menu = ({ isApproved }) => {
             <SwitcherItemStyled onClick={() => {redirect("/help")}}>
               Help
             </SwitcherItemStyled>
-            {user &&
+            {approved &&
               <SwitcherItemStyled onClick={() => {redirect("/profile")}}>
                 Profile
               </SwitcherItemStyled>

--- a/src/components/Profile/ProfilePage.js
+++ b/src/components/Profile/ProfilePage.js
@@ -4,30 +4,7 @@ import { useHistory } from "react-router-dom";
 import { AppContext } from "../../api/AppContext";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import PageLayout from "../PageLayout";
-import { ResponsiveContainer } from '../pageStyles';
 import { ProfileForm } from "./ProfileForm";
-
-export const DeniedPage = () => (
-  <PageLayout title="Your account needs further review">
-    <p>
-      To start the review process, please visit this link to provide more information: <a href="https://blockpower.link/manualreview">
-        https://blockpower.link/manualreview
-      </a>
-    </p>
-  </PageLayout>
-);
-
-export const NoNewSignupsPage = () => (
-  <PageLayout title='This site is now closed to new Voting Ambassador sign-ups'>
-    <ResponsiveContainer>
-      <p>
-        If you are trying to access an existing account, please contact
-        support@blockpower.vote. To sign up for a new Voting Ambassador
-        account, please go to <a href='https://app.blockpower.vote/ambassadors'>https://app.blockpower.vote/ambassadors</a>
-      </p>
-    </ResponsiveContainer>
-  </PageLayout>
-);
 
 export const ProfilePage = () => {
   const [err, setErr] = useState(false);
@@ -43,9 +20,6 @@ export const ProfilePage = () => {
       else history.push("/");
     }
   };
-
-  if (process.env.REACT_APP_NO_NEW_SIGNUPS) return <NoNewSignupsPage />;
-  if (user?.msg === "Your account is locked.") return <DeniedPage/>;
 
   return <PageLayout title="Edit Your Profile">
     <ProfileForm
@@ -76,9 +50,6 @@ export const SignupPage = () => {
       }
     }
   };
-
-  if (process.env.REACT_APP_NO_NEW_SIGNUPS) return <NoNewSignupsPage />;
-  if (user?.msg === "Your account is locked.") return <DeniedPage/>;
 
   return <PageLayout title="Please Enter Your Details">
     <ProfileForm

--- a/src/components/SignupsClosedPage.js
+++ b/src/components/SignupsClosedPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import PageLayout from "./PageLayout";
+import { ResponsiveContainer } from './pageStyles';
+
+export default () => (
+  <PageLayout title='This site is now closed to new Voting Ambassador sign-ups'>
+    <ResponsiveContainer>
+      <p>
+        If you are trying to access an existing account, please contact
+        support@blockpower.vote. To sign up for a new Voting Ambassador
+        account, please go to <a href='https://app.blockpower.vote/ambassadors'>https://app.blockpower.vote/ambassadors</a>
+      </p>
+    </ResponsiveContainer>
+  </PageLayout>
+);

--- a/src/components/UnapprovedPage.js
+++ b/src/components/UnapprovedPage.js
@@ -1,29 +1,15 @@
 import React from 'react'
 import PageLayout from './PageLayout'
-import { AppContext } from '../api/AppContext';
+import { ResponsiveContainer } from './pageStyles';
 
-export default () => {
-  const { user } = React.useContext(AppContext);
-  return <PageLayout title="Unapproved">
-    <p>
-      You are registered as:
-    </p>
-    <blockquote>
+export default () => (
+  <PageLayout title="Your account needs further review">
+    <ResponsiveContainer>
       <p>
-        Name: {user.first_name} {user.last_name}
-      <br/>
-        City: {user.address.city}, {user.address.state}
-      <br/>
-        Zip: {user.address.zip}
-      <br/>
-        Phone: {user.phone}
-      <br/>
-        Email: {user.email}
+        To start the review process, please visit this link to provide more information: <a href="https://blockpower.link/manualreview">
+          https://blockpower.link/manualreview
+        </a>
       </p>
-    </blockquote>
-    <p>
-      We're sorry; we can't automatically set you up as an Ambassador.
-      Please contact a BlockPower staff member to assist you.
-    </p>
-  </PageLayout>;
-};
+    </ResponsiveContainer>
+  </PageLayout>
+);

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -15,11 +15,16 @@ export const useAuth = (token, api) => {
   };
 
   const fetchUser = async () => {
-    const { error, data } = await api.fetchAmbassador()
+    let { data, error } = await api.fetchAmbassador()
     if (error) {
+      console.log('error', {error, data});
       // TODO: Change authenticated to "in_signup_process"
       if (error?.msg === 'No current ambassador') {
-        setAuthenticated(true)
+        setAuthenticated(true);
+      }
+      if (error?.msg === 'Your account is locked.') {
+        setAuthenticated(true);
+        setUser({ locked: true });
       }
       setLoading(false);
       return { error };

--- a/src/router.js
+++ b/src/router.js
@@ -20,6 +20,8 @@ import HomePage from "./components/HomePage";
 import TrainingPage from "./components/TrainingPage";
 import QuizCompletedPage from "./components/QuizCompletedPage";
 import UnapprovedPage from "./components/UnapprovedPage";
+import LockedPage from "./components/LockedPage";
+import SignupsClosedPage from "./components/SignupsClosedPage";
 import PaymentsPage from "./components/Payments/AddPage";
 import PaymentsHomePage from "./components/Payments/PaymentsPage";
 import Chime from "./components/Payments/ChimePage";
@@ -69,7 +71,7 @@ export default () => {
 
   return (
     <div style={{ position: "relative", minHeight: "100vh" }}>
-      <Menu isApproved={user?.approved} />
+      <Menu />
       <Switch>
         <Route exact path="/help" component={Help} />
         <Route exact path="/terms" component={Terms} />
@@ -79,6 +81,12 @@ export default () => {
 
         <Route exact path="/login" component={LogIn} />
         { !authenticated && <Redirect to='/login' /> }
+
+        <Route exact path="/closed" component={SignupsClosedPage} />
+        { process.env.REACT_APP_NO_NEW_SIGNUPS && <Redirect to='/closed' /> }
+
+        <Route exact path="/locked" component={LockedPage} />
+        { user?.locked && <Redirect to='/locked' /> }
 
         <Route exact path="/signup" component={SignupPage} />
         { !user?.signup_completed && <Redirect to='/signup' /> }

--- a/src/router.js
+++ b/src/router.js
@@ -29,6 +29,17 @@ import Terms from "./components/Help/TermsPage";
 import Privacy from "./components/Help/PrivacyPage";
 import HubSpot from "./components/HubSpot";
 
+// When OAuth passes back our JWT token, it inserts /auth/ into the URL
+// (probably for some outdated reason).  This removes that from the URL.
+const redirectToCanonicalUrl = () => {
+  const match = window.location.href.match(/(.*)\/auth\W*#(.*)/);
+  if (match) {
+    window.location = match[1] + '/#' + match[2];
+    return true;
+  }
+  return false;
+};
+
 // Grabs the prefill data from the URL fragment and puts it in local storage.
 const capturePrefillData = (callback) => {
   const fragment = decodeURIComponent(window.location.hash);
@@ -49,6 +60,8 @@ export default () => {
   const { loading, authenticated, user } = React.useContext(AppContext);
   const [ signupPrefill, setSignupPrefill ] = useLocalStorage("signup_prefill", {});
   useAnalytics();
+
+  if (redirectToCanonicalUrl()) return <Loading />;
   if (loading) return <Loading />;
 
   capturePrefillData(setSignupPrefill);


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/175999332 — make Unapproved page say "Your account needs further review"

Fixes https://www.pivotaltracker.com/story/show/175993222 — omit Profile from nav menu if not approved

Fixes https://www.pivotaltracker.com/story/show/176002527 — redirect to remove `/auth/` from the middle of the URL

Moves all the "off-ramp" pages (unapproved, locked, signups closed) to their own files, and makes the Router responsible for redirecting to the appropriate off-ramp.

Also cleans up the way we represent the locked state — it's a flag instead of checking for the string "Your account is locked" from the back-end