### PR TITLE
Add an env variable that forces the State field in the signup form.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,8 @@ REACT_APP_CHIME_URL=https://chime.com
 
 # URL of the page to direct users to for Voting Ambassador training
 REACT_APP_TRAINING_URL=https://www.blockpower.vote/ambassadors/civics
+
+# If present, the "State" field in the signup form will be disabled and
+# forced to this value, and the "State" field in the profile form will
+# also be disabled.  If unset, the state will be editable as normal.
+REACT_APP_PROFILE_FORCE_STATE=GA

--- a/src/components/Profile/AddressForm.js
+++ b/src/components/Profile/AddressForm.js
@@ -40,7 +40,7 @@ const RowRight = styled.div`
   }
 `
 
-export default ({ user }) => (
+export default ({ user, disableState }) => (
   <>
     <FormGroup legendText="">
       <TextInput
@@ -72,6 +72,7 @@ export default ({ user }) => (
             labelText="State*"
             defaultValue={user.address?.state}
             required
+            disabled={disableState}
           />
         </RowCenter>
         <RowRight>

--- a/src/components/Profile/ProfileForm.js
+++ b/src/components/Profile/ProfileForm.js
@@ -42,7 +42,7 @@ const SubmissionContainer = styled.div`
   margin-top: ${spacing[8]};
 `;
 
-export const ProfileForm = ({ user, onSubmit, loading, err, disablePhone, disableEmail }) => <ResponsiveContainer>
+export const ProfileForm = ({ user, onSubmit, loading, err, disablePhone, disableEmail, disableState }) => <ResponsiveContainer>
   <Form onSubmit={(e) => {
     e.preventDefault();
     const formData = new FormData(e.target);
@@ -121,7 +121,7 @@ export const ProfileForm = ({ user, onSubmit, loading, err, disablePhone, disabl
       </Row>
     </FormGroup>
     <Divider />
-    <AddressForm user={user} />
+    <AddressForm user={user} disableState={disableState} />
     <SubmissionContainer>
       {err && (
         <InlineNotificationStyled

--- a/src/components/Profile/ProfilePage.js
+++ b/src/components/Profile/ProfilePage.js
@@ -6,6 +6,8 @@ import { useLocalStorage } from "../../hooks/useLocalStorage";
 import PageLayout from "../PageLayout";
 import { ProfileForm } from "./ProfileForm";
 
+const FORCE_STATE = process.env.REACT_APP_PROFILE_FORCE_STATE;
+
 export const ProfilePage = () => {
   const [err, setErr] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -33,6 +35,7 @@ export const ProfilePage = () => {
       loading={loading}
       disablePhone
       disableEmail
+      disableState={!!FORCE_STATE}
       err={err}
     />
   </PageLayout>;
@@ -62,11 +65,17 @@ export const SignupPage = () => {
     }
   };
 
+  const prefill = {...user, ...signupPrefill};
+  if (FORCE_STATE) {
+    prefill.address = {...prefill.address, state: FORCE_STATE};
+  }
+
   return <PageLayout title="Please Enter Your Details">
     <ProfileForm
-      user={{...user, ...signupPrefill}}
+      user={prefill}
       onSubmit={onSubmit}
       loading={loading}
+      disableState={!!FORCE_STATE}
       err={err}
     />
   </PageLayout>;


### PR DESCRIPTION
The new variable is defined thus:
```
# If present, the "State" field in the signup form will be disabled and
# forced to this value, and the "State" field in the profile form will
# also be disabled.  If unset, the state will be editable as normal.
REACT_APP_PROFILE_FORCE_STATE=GA
```
