### PR TITLE
Fix behaviour when there are multiple states to select from

### DIFF
--- a/src/components/Profile/AddressForm.js
+++ b/src/components/Profile/AddressForm.js
@@ -73,8 +73,8 @@ export default ({ user, stateOptions, onStateSelected }) => {
             name="state"
             items={stateOptions}
             titleText="State*"
-            selectedItem={user.address?.state}
-            onChange={(e) => { stateRef.current.value = e.target.selectedItem; }}
+            initialSelectedItem={user.address?.state}
+            onChange={(e) => { stateRef.current.value = e.selectedItem; }}
             required
           />
           <input name="state" type="hidden" value={user.address?.state} ref={stateRef} />


### PR DESCRIPTION
Because the Carbon `<Dropdown>` component is stupid, we have to do a bunch of workarounds to make the Dropdown element behave like a proper form field.

This fix is only needed for when there is more than one state to choose from; it's not launch-blocking though we may want to test with it just so we don't have to retest later.  I've tested it locally and it works.