### PR TITLE
Fix the bug that causes the email field to be erased when an Ambassador updates their profile.

### DIFF
--- a/src/components/Profile/ProfileForm.js
+++ b/src/components/Profile/ProfileForm.js
@@ -95,6 +95,8 @@ export const ProfileForm = ({ user, onSubmit, loading, err, disablePhone, disabl
         disabled={disablePhone}
       />
     </FormGroup>
+    {disablePhone &&
+        <input name="phone" type="hidden" value={user.phone} />}
     <FormGroup legendText="">
       <TextInput
         id="email"
@@ -106,6 +108,8 @@ export const ProfileForm = ({ user, onSubmit, loading, err, disablePhone, disabl
         disabled={disableEmail}
       />
     </FormGroup>
+    {disableEmail &&
+        <input name="email" type="hidden" value={user.email} />}
     <FormGroup legendText="">
       <Row>
         <DatePicker datePickerType="single">


### PR DESCRIPTION
Disabled fields aren't submitted, so when they're disabled this adds a hidden input field with the same contents for the phone and email fields.